### PR TITLE
Update golangci-lint to latest - 1.50.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ bootstrap: ## Download and install all project dependencies (+ prep tooling in t
 	go mod download
 	cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % env GOBIN=$(BIN) go install %
 	# install golangci-lint
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) v1.47.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) v1.50.1
 	# install pkger
 	cd $(TMP) && curl -sLO https://github.com/markbates/pkger/releases/download/v0.17.0/pkger_0.17.0_$(shell uname)_x86_64.tar.gz && \
 		tar -xzvf pkger_0.17.0_$(shell uname)_x86_64.tar.gz pkger && \


### PR DESCRIPTION
To resolve "can't load fmt" error, seen when running: -

.tmp/bin/golangci-lint --version

etc.

Signed-off-by: Dave Hay <david_hay@uk.ibm.com>

# Additional details

## With default `1.47.2` included with `go-bouncer`

`make bootstrap`

```text
Downloading dependencies
# prep temp dirs
mkdir -p ./.tmp
mkdir -p ./.tmp/results
mkdir -p /root/go/src/github.com/wagoodman/go-bouncer/.tmp/bin
# download install project dependencies + tooling
go mod download
cat tools.go | grep _ | awk -F'"' '{print $2}' | xargs -tI % env GOBIN=/root/go/src/github.com/wagoodman/go-bouncer/.tmp/bin go install %
env 'GOBIN=/root/go/src/github.com/wagoodman/go-bouncer/.tmp/bin' go install github.com/google/licenseclassifier/tools/license_serializer
# install golangci-lint
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /root/go/src/github.com/wagoodman/go-bouncer/.tmp/bin v1.47.2
golangci/golangci-lint info checking GitHub for tag 'v1.47.2'
golangci/golangci-lint info found version: 1.47.2 for v1.47.2/linux/amd64
golangci/golangci-lint info installed /root/go/src/github.com/wagoodman/go-bouncer/.tmp/bin/golangci-lint
# install pkger
cd ./.tmp && curl -sLO https://github.com/markbates/pkger/releases/download/v0.17.0/pkger_0.17.0_Linux_x86_64.tar.gz && \
	tar -xzvf pkger_0.17.0_Linux_x86_64.tar.gz pkger && \
	mv pkger /root/go/src/github.com/wagoodman/go-bouncer/.tmp/bin
pkger
# install goreleaser
GOBIN=/root/go/src/github.com/wagoodman/go-bouncer/.tmp/bin go install github.com/goreleaser/goreleaser@v1.3.1
```

`make`

```text
Running linters
files with gofmt issues: []
/root/go/src/github.com/wagoodman/go-bouncer/.tmp/bin/golangci-lint run --tests=false --config .golangci.yaml
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt

goroutine 1 [running]:
github.com/go-critic/go-critic/checkers.init.22()
	github.com/go-critic/go-critic@v0.6.3/checkers/embedded_rules.go:47 +0x4b4
make: *** [Makefile:75: lint] Error 2
```

`ls -al .tmp/bin/golangci-lint`

```text
-rwxr-xr-x 1 root root 23461888 Dec  2 09:33 .tmp/bin/golangci-lint
```

`.tmp/bin/golangci-lint --version`

```text
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt

goroutine 1 [running]:
github.com/go-critic/go-critic/checkers.init.22()
	github.com/go-critic/go-critic@v0.6.3/checkers/embedded_rules.go:47 +0x4b4
```

Match other known issues with older versions of `golangci-lint` such as [ Panic since update to v1.43.0 (load embedded ruleguard rules: rules/rules.go:13: can't load fmt) #2374 ](https://github.com/golangci/golangci-lint/issues/2374) and [ go-critic/ruleguard: load embedded ruleguard rules: rules/rules.go:13: can't load fmt #3107 ](https://github.com/golangci/golangci-lint/issues/3107)

With current latest `1.50.1` - as per [golangci-lint/releases](https://github.com/golangci/golangci-lint/releases)

`.tmp/bin/golangci-lint --version`

```text
golangci-lint has version 1.50.1 built from 8926a95f on 2022-10-22T10:50:47Z
```

`ls -al .tmp/bin/golangci-lint`

```text
-rwxr-xr-x 1 root root 24383488 Dec  2 09:38 .tmp/bin/golangci-lint
```

( having run `make bootstrap` )
