### PR TITLE
Fix ioutil deprecation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ bootstrap: ## Download and install all project dependencies (+ prep tooling in t
 	go mod download
 	cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % env GOBIN=$(BIN) go install %
 	# install golangci-lint
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) v1.47.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) v1.50.1
 	# install pkger
 	cd $(TMP) && curl -sLO https://github.com/markbates/pkger/releases/download/v0.17.0/pkger_0.17.0_$(shell uname)_x86_64.tar.gz && \
 		tar -xzvf pkger_0.17.0_$(shell uname)_x86_64.tar.gz pkger && \

--- a/bouncer/finder.go
+++ b/bouncer/finder.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/google/licenseclassifier"
@@ -35,7 +35,7 @@ func licenseDBArchiveFetcher() ([]byte, error) {
 	}
 
 	defer f.Close()
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 func (r LicenseFinder) Find() (<-chan LicenseResult, error) {

--- a/bouncer/licenses/classifier.go
+++ b/bouncer/licenses/classifier.go
@@ -16,7 +16,7 @@ package licenses
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/google/licenseclassifier"
 )
@@ -88,7 +88,7 @@ func (c *googleClassifier) Identify(licensePath string) (string, Type, error) {
 	if licensePath == "" {
 		return "", Unknown, nil
 	}
-	content, err := ioutil.ReadFile(licensePath)
+	content, err := os.ReadFile(licensePath)
 	if err != nil {
 		return "", "", err
 	}

--- a/bouncer/licenses/find.go
+++ b/bouncer/licenses/find.go
@@ -17,7 +17,7 @@ package licenses
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 )
@@ -57,7 +57,7 @@ func findUpwards(dir string, r *regexp.Regexp, stopAt []*regexp.Regexp, predicat
 	start := dir
 	// Stop once dir matches a stopAt regexp or dir is the filesystem root
 	for !matchAny(stopAt, dir) {
-		dirContents, err := ioutil.ReadDir(dir)
+		dirContents, err := os.ReadDir(dir)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
    Updated: -

    - bouncer/licenses/classifier.go
    - bouncer/licenses/find.go:20
    - bouncer/finder.go

    to remove deprecated ioutil library

    Signed-off-by: Dave Hay <david_hay@uk.ibm.com>