### PR TITLE
feat: additional release targets for windows and freebsd

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -8,6 +8,8 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
+      - freebsd
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
This PR just adds goreleaser targets for windows and freebsd.